### PR TITLE
Add distinction between Authors & Developers

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -146,11 +146,18 @@
 			if(!is_null($context['alert'])) return;
 
 			// Site in maintenance mode
-			if(Symphony::Configuration()->get('enabled', 'maintenance_mode') == 'yes' && Symphony::Engine()->Author->isDeveloper()) {
-				Administration::instance()->Page->pageAlert(
-					__('This site is currently in maintenance mode.') . ' <a href="' . SYMPHONY_URL . '/system/preferences/?action=toggle-maintenance-mode&amp;redirect=' . getCurrentPage() . '">' . __('Restore?') . '</a>',
-					Alert::NOTICE
-				);
+			if(Symphony::Configuration()->get('enabled', 'maintenance_mode') == 'yes') {
+				if (Symphony::Engine()->Author->isDeveloper()) {
+					Administration::instance()->Page->pageAlert(
+						__('This site is currently in maintenance mode.') . ' <a href="' . SYMPHONY_URL . '/system/preferences/?action=toggle-maintenance-mode&amp;redirect=' . getCurrentPage() . '">' . __('Restore?') . '</a>',
+						Alert::NOTICE
+					);
+				} else {
+Administration::instance()->Page->pageAlert(
+						__('This site is currently in maintenance mode.'),
+						Alert::NOTICE
+					);
+				}
 			}
 		}
 
@@ -190,7 +197,7 @@
 		 * @param array $context
 		 *  delegate context
 		 */
-		public function __checkForMaintenanceMode($context) {
+		public function __checkForMaintenanceMode($context) {	
 			if(!Symphony::Engine()->isLoggedIn() && Symphony::Configuration()->get('enabled', 'maintenance_mode') == 'yes' || !Symphony::Engine()->Author->isDeveloper()){
 
 				// Find custom maintenance page

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -146,7 +146,7 @@
 			if(!is_null($context['alert'])) return;
 
 			// Site in maintenance mode
-			if(Symphony::Configuration()->get('enabled', 'maintenance_mode') == 'yes') {
+			if(Symphony::Configuration()->get('enabled', 'maintenance_mode') == 'yes' && Symphony::Engine()->Author->isDeveloper()) {
 				Administration::instance()->Page->pageAlert(
 					__('This site is currently in maintenance mode.') . ' <a href="' . SYMPHONY_URL . '/system/preferences/?action=toggle-maintenance-mode&amp;redirect=' . getCurrentPage() . '">' . __('Restore?') . '</a>',
 					Alert::NOTICE
@@ -191,7 +191,7 @@
 		 *  delegate context
 		 */
 		public function __checkForMaintenanceMode($context) {
-			if(!Symphony::Engine()->isLoggedIn() && Symphony::Configuration()->get('enabled', 'maintenance_mode') == 'yes'){
+			if(!Symphony::Engine()->isLoggedIn() && Symphony::Configuration()->get('enabled', 'maintenance_mode') == 'yes' || !Symphony::Engine()->Author->isDeveloper()){
 
 				// Find custom maintenance page
 				$context['row'] = Symphony::Database()->fetchRow(0,


### PR DESCRIPTION
Hi, The text in preferences says:

> Maintenance mode will redirect all visitors, other than **developers**, to the specified maintenance page.

But it does not redirect _authors_ to the maintenance page. This pull request fixes this.

It also addresses another (possible) issue that the backend Alert for _authors_ had a link to restore the maintenance mode when _authors_ are not currently privileged to make this change. I have removed the link form the backend Alert.

If this is useful please do pull the changes in.