### PR TITLE
Useragent Support

### DIFF
--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -15,6 +15,9 @@
 		</author>
 	</authors>
 	<releases>
+		<release version="1.9" date="2015-03-17" min="2.4" max="2.6.x">
+			- Add Useragent Whitelist support
+		</release>
 		<release version="1.8.3" date="2015-03-11" min="2.4" max="2.6.x">
 			- Mark compatibility with Symphony 2.6+
 		</release>


### PR DESCRIPTION
In addition to IP Whitelisting add the ability to whitelist useragents. This comes in handy when you want to allow a bot to spider your website prior to launch.

Use Cases:

1. Recommendation scripts based on third party services indexing the website. Great before launch / or on a staging environment
2. Automated testing to check if there are unexpected 404s or other errors on the website.