### PR TITLE
Quick fix for empty useragent whitelist

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -87,7 +87,9 @@ Class extension_maintenance_mode extends Extension
 
         // Useragent White list
         $label = Widget::Label(__('Useragent Whitelist'));
-        $useragent = implode("\r\n",json_decode(Symphony::Configuration()->get('useragent_whitelist', 'maintenance_mode')));
+        $whitelist = Symphony::Configuration()->get('useragent_whitelist', 'maintenance_mode');
+        if ($whitelist) 
+            $useragent = implode("\r\n",json_decode(Symphony::Configuration()->get('useragent_whitelist', 'maintenance_mode')));
         $label->appendChild(Widget::Textarea('settings[maintenance_mode][useragent_whitelist]', 5, 50, $useragent));
         $group->appendChild($label);
 


### PR DESCRIPTION
Quick fix for a warning on call to implode() when an empty useragent whitelist is read. There's probably a cleaner or more advanced way to do this.
It Happened on a 2.6.0 site that has just been upgraded from 2.5.3.

The warning is:
![screen shot 2015-03-19 at 1 16 29 pm](https://cloud.githubusercontent.com/assets/1185108/6737668/115d46e2-ce3b-11e4-9ad0-6c6180d007fb.png)