### PR TITLE
Quick fix for warning on empty useragent whitelist

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -87,9 +87,10 @@ Class extension_maintenance_mode extends Extension
 
         // Useragent White list
         $label = Widget::Label(__('Useragent Whitelist'));
-        $whitelist = Symphony::Configuration()->get('useragent_whitelist', 'maintenance_mode');
-        if ($whitelist)
-            $useragent = implode("\r\n",json_decode($whitelist));
+        $whitelist = json_decode(Symphony::Configuration()->get('useragent_whitelist', 'maintenance_mode'));
+        if (is_array($whitelist) && !empty($whitelist)) {
+            $useragent = implode("\r\n",$whitelist);
+        }
         $label->appendChild(Widget::Textarea('settings[maintenance_mode][useragent_whitelist]', 5, 50, $useragent));
         $group->appendChild($label);
 

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -88,8 +88,8 @@ Class extension_maintenance_mode extends Extension
         // Useragent White list
         $label = Widget::Label(__('Useragent Whitelist'));
         $whitelist = Symphony::Configuration()->get('useragent_whitelist', 'maintenance_mode');
-        if ($whitelist) 
-            $useragent = implode("\r\n",json_decode(Symphony::Configuration()->get('useragent_whitelist', 'maintenance_mode')));
+        if ($whitelist)
+            $useragent = implode("\r\n",json_decode($whitelist));
         $label->appendChild(Widget::Textarea('settings[maintenance_mode][useragent_whitelist]', 5, 50, $useragent));
         $group->appendChild($label);
 

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -87,7 +87,9 @@ Class extension_maintenance_mode extends Extension
 
         // Useragent White list
         $label = Widget::Label(__('Useragent Whitelist'));
-        $useragent = implode("\r\n",json_decode(Symphony::Configuration()->get('useragent_whitelist', 'maintenance_mode')));
+        $whitelist = Symphony::Configuration()->get('useragent_whitelist', 'maintenance_mode');
+        if ($whitelist) 
+            $useragent = implode("\r\n",json_decode(Symphony::Configuration()->get('useragent_whitelist', 'maintenance_mode')));
         $label->appendChild(Widget::Textarea('settings[maintenance_mode][useragent_whitelist]', 5, 50, $useragent));
         $group->appendChild($label);
 


### PR DESCRIPTION
After upgrading to 2.6.0, started getting an error when going into preferences pane, a warning such as follows:

![screen shot 2015-03-19 at 1 16 29 pm](https://cloud.githubusercontent.com/assets/1185108/6737840/3b180ebc-ce3c-11e4-98be-8b850ccf3a17.png)

Added a check for the user agent list to not be null before doing the implode().